### PR TITLE
Fixed issue 124

### DIFF
--- a/cogs/logging.py
+++ b/cogs/logging.py
@@ -44,10 +44,10 @@ class Logging(commands.Cog):
                               color=discord.Color.green())
         await ctx.send(embed=embed)
 
-    @commands.command(usage="logrun [member (leader)] [num_runs]", description="Log a full run (or multiple runs) manually.")
+    @commands.command(usage="logrun [num_runs] [member (leader)]", description="Log a full run (or multiple runs) manually.")
     @commands.guild_only()
     @checks.is_rl_or_higher_check()
-    async def logrun(self, ctx, member: utils.MemberLookupConverter=None, number=1):
+    async def logrun(self, ctx, number, member: utils.MemberLookupConverter=None):
         if not member:
             member = ctx.author
 


### PR DESCRIPTION
This should fix #124. Please note that the usage of the command has changed from `logrun [member (leader)] [num_runs]` to `logrun [num_runs] [member (leader)]`.