### PR TITLE
Removed servers that are no longer in service

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -699,8 +699,8 @@ async def get_event_servers(client, type):
         return None
 
 
-servers = {"US" : ("USWest2", "USWest", "USSouthWest", "USSouth3", "USSouth2", "USSouth", "USNorthWest", "USMidWest2", "USMidWest", "USEast3", "USEast2", "USEast"),
-           "EU" : ("EUSouthWest", "EUSouth", "EUNorth2", "EUNorth")}
+servers = {"US" : ("USWest", "USSouthWest", "USSouth3", "USSouth", "USNorthWest", "USMidWest2", "USMidWest", "USEast2", "USEast"),
+           "EU" : ("EUSouthWest", "EUNorth")}
 
 def get_server(is_us=True):
     res = random.choice(servers["EU"]) if is_us else random.choice(servers["US"])


### PR DESCRIPTION
As stated by the [patch notes](http://remaster.realmofthemadgod.com/?p=2235), 
> We are removing the servers Asia East, EUEast2, EUSouth, EUNorth2, USWest2, USEast3, USEast4 and USSouth2.